### PR TITLE
Add configurable severity level(s) and update argparse namespace

### DIFF
--- a/src/security_constraints/common.py
+++ b/src/security_constraints/common.py
@@ -1,7 +1,20 @@
 """This module contains common definitions for use in any other module."""
 import abc
+import argparse
 import dataclasses
-from typing import Dict, List
+from typing import IO, Dict, List, Optional
+
+
+class ArgumentNamespace(argparse.Namespace):
+    """Namespace for arguments."""
+
+    dump_config: bool
+    debug: bool
+    version: bool
+    output: Optional[IO]
+    ignore_ids: List[str]
+    config: Optional[str]
+    severities: List[str]
 
 
 class SecurityConstraintsError(Exception):
@@ -25,6 +38,7 @@ class Configuration:
     """
 
     ignore_ids: List[str] = dataclasses.field(default_factory=list)
+    severities: List[str] = dataclasses.field(default_factory=list)
 
     def to_dict(self) -> Dict:
         return dataclasses.asdict(self)

--- a/src/security_constraints/main.py
+++ b/src/security_constraints/main.py
@@ -9,7 +9,7 @@ if sys.version_info >= (3, 8):
 else:
     from importlib_metadata import version
 
-from typing import IO, Any, List, Optional, Sequence
+from typing import IO, List, Optional, Sequence
 
 import yaml
 

--- a/src/security_constraints/main.py
+++ b/src/security_constraints/main.py
@@ -14,6 +14,7 @@ from typing import IO, Any, List, Optional, Sequence
 import yaml
 
 from security_constraints.common import (
+    ArgumentNamespace,
     Configuration,
     PackageConstraints,
     SecurityConstraintsError,
@@ -25,11 +26,11 @@ from security_constraints.github_security_advisory import GithubSecurityAdvisory
 LOGGER = logging.getLogger(__name__)
 
 
-def get_security_vulnerability_database_apis() -> List[
-    SecurityVulnerabilityDatabaseAPI
-]:
+def get_security_vulnerability_database_apis(
+    severities: Optional[List[str]] = None,
+) -> List[SecurityVulnerabilityDatabaseAPI]:
     """Return the APIs to use for fetching vulnerabilities."""
-    return [GithubSecurityAdvisoryAPI()]
+    return [GithubSecurityAdvisoryAPI(severities=severities)]
 
 
 def fetch_vulnerabilities(
@@ -152,7 +153,7 @@ def format_constraints_file_line(
     return f"{constraints}" f"  # {vulnerability.name} (ID: {vulnerability.identifier})"
 
 
-def get_args() -> Any:
+def get_args() -> ArgumentNamespace:
     """Parse arguments from the command line and return them."""
     parser = argparse.ArgumentParser(
         description=(
@@ -203,7 +204,18 @@ def get_args() -> Any:
             f" Supported keys: {Configuration.supported_keys()}"
         ),
     )
-    return parser.parse_args()
+    parser.add_argument(
+        "--severities",
+        type=str,
+        action="store",
+        nargs="+",
+        default=["critical"],
+        help=(
+            "Vulnerability severities include."
+            " Can also be given as 'severities' in config file."
+        ),
+    )
+    return parser.parse_args(namespace=ArgumentNamespace())
 
 
 def get_config(config_file: Optional[str]) -> Configuration:
@@ -243,7 +255,8 @@ def main() -> int:
                 "'output' is not a stream! This suggests a programming error"
             )
         config: Configuration = get_config(config_file=args.config)
-        config.ignore_ids.extend(args.ignore_ids)
+        config.ignore_ids.extend(sorted(args.ignore_ids))
+        config.severities.extend(sorted(args.severities))
 
         if args.dump_config:
             yaml.safe_dump(config.to_dict(), stream=sys.stdout)
@@ -251,7 +264,7 @@ def main() -> int:
 
         apis: List[
             SecurityVulnerabilityDatabaseAPI
-        ] = get_security_vulnerability_database_apis()
+        ] = get_security_vulnerability_database_apis(severities=args.severities)
 
         vulnerabilities: List[SecurityVulnerability] = fetch_vulnerabilities(apis)
         vulnerabilities = filter_vulnerabilities(config, vulnerabilities)


### PR DESCRIPTION
This patch adds in severity level arguments and alters the graphql template for github actions.  It assumes that the user knows the proper levels and adding new providers may require setting up mappings against a strict enum choice or some such.