### PR TITLE
Test improvements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,13 +32,14 @@ omit = [
   "*/venv/*",
   "test/*",
 ]
+plugins = ["coverage_pyver_pragma"]
 
 [tool.coverage.report]
 show_missing = true
 fail_under = 100
 
 [tool.pytest.ini_options]
-addopts = "--cov --cov-report term --random-order"
+addopts = "--cov='security_constraints' --random-order"
 minversion = "6.0"
 usefixtures = ["requests_mock"]
 testpaths = ["test"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,20 @@ build-backend = "setuptools.build_meta"
 where = ["src"]
 namespaces = false
 
+[tool.coverage.run]
+branch = true
+omit = [
+  "*/.venv/*",
+  "*/venv/*",
+  "test/*",
+]
+
+[tool.coverage.report]
+show_missing = true
+fail_under = 100
+
 [tool.pytest.ini_options]
+addopts = "--cov --cov-report term --random-order"
 minversion = "6.0"
 usefixtures = ["requests_mock"]
 testpaths = ["test"]

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,6 @@
 pytest
 pytest-cov
+coverage_pyver_pragma
 pytest-random-order
 pytest-integration
 requests-mock

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,6 @@
 pytest
+pytest-cov
+pytest-random-order
+pytest-integration
 requests-mock
 freezegun

--- a/src/security_constraints/common.py
+++ b/src/security_constraints/common.py
@@ -7,9 +7,9 @@ import sys
 from typing import IO, Any, Dict, List, Optional, Set, get_type_hints
 
 if sys.version_info >= (3, 8):
-    from typing import TypedDict
+    from typing import TypedDict  # pragma: no cover
 else:
-    from typing_extensions import TypedDict
+    from typing_extensions import TypedDict  # pragma: no cover
 
 
 class SeverityLevel(str, enum.Enum):
@@ -129,7 +129,7 @@ class Configuration:
                 if isinstance(obj, set):
                     # Use ordered list for sets
                     return sorted(obj)
-                return obj
+                return obj  # pragma: no cover
 
             return {key: convert(value) for key, value in data}
 

--- a/src/security_constraints/common.py
+++ b/src/security_constraints/common.py
@@ -3,13 +3,19 @@ import abc
 import argparse
 import dataclasses
 import enum
-import sys
-from typing import IO, Any, Dict, List, Optional, Set, get_type_hints
+from typing import IO, TYPE_CHECKING, Any, Dict, List, Optional, Set, get_type_hints
 
-if sys.version_info >= (3, 8):
-    from typing import TypedDict  # pragma: no cover
-else:
-    from typing_extensions import TypedDict  # pragma: no cover
+if TYPE_CHECKING:  # pragma: no cover
+    import sys
+
+    if sys.version_info >= (3, 8):
+        from typing import TypedDict
+    else:
+        from typing_extensions import TypedDict
+
+    class _ConfigurationKwargs(TypedDict, total=False):
+        ignore_ids: Set[str]
+        min_severity: "SeverityLevel"
 
 
 class SeverityLevel(str, enum.Enum):
@@ -137,11 +143,7 @@ class Configuration:
 
     @classmethod
     def from_dict(cls, in_dict: Dict) -> "Configuration":
-        class Kwargs(TypedDict, total=False):
-            ignore_ids: Set[str]
-            min_severity: SeverityLevel
-
-        kwargs: Kwargs = {}
+        kwargs: _ConfigurationKwargs = {}
         if "ignore_ids" in in_dict:
             kwargs["ignore_ids"] = set(in_dict["ignore_ids"])
         if "min_severity" in in_dict:

--- a/src/security_constraints/main.py
+++ b/src/security_constraints/main.py
@@ -292,6 +292,6 @@ def main() -> int:
         return 2
     else:
         return 0
-    finally:
+    finally:  # pragma: no cover (py39)
         if output is not None and not output.isatty():
             output.close()

--- a/src/security_constraints/main.py
+++ b/src/security_constraints/main.py
@@ -5,9 +5,9 @@ import sys
 from datetime import datetime, timezone
 
 if sys.version_info >= (3, 8):
-    from importlib.metadata import version
+    from importlib.metadata import version  # pragma: no cover
 else:
-    from importlib_metadata import version
+    from importlib_metadata import version  # pragma: no cover
 
 from typing import IO, List, Optional, Sequence, Set
 

--- a/src/security_constraints/main.py
+++ b/src/security_constraints/main.py
@@ -292,6 +292,6 @@ def main() -> int:
         return 2
     else:
         return 0
-    finally:  # pragma: no cover (py39)
+    finally:  # pragma: no cover (py38 or py39)
         if output is not None and not output.isatty():
             output.close()

--- a/src/security_constraints/main.py
+++ b/src/security_constraints/main.py
@@ -5,9 +5,9 @@ import sys
 from datetime import datetime, timezone
 
 if sys.version_info >= (3, 8):
-    from importlib.metadata import version  # pragma: no cover
+    from importlib.metadata import version  # pragma: no cover (<py38)
 else:
-    from importlib_metadata import version  # pragma: no cover
+    from importlib_metadata import version  # pragma: no cover (>=py38)
 
 from typing import IO, List, Optional, Sequence, Set
 

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -1,10 +1,12 @@
 from unittest.mock import Mock
 
+import pytest
 import yaml
 
 from security_constraints.main import main
 
 
+@pytest.mark.integration_test
 def test_main_flow(
     frozen_time, tmp_path, github_token, monkeypatch, mock_version: Mock, requests_mock
 ) -> None:

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -89,6 +89,15 @@ def test_get_security_vulnerability_database_apis(monkeypatch) -> None:
             ),
             PackageConstraints(package="pystuff", specifiers=["<0.0.1"]),
         ),
+        (
+            SecurityVulnerability(
+                name="CVE-2020-123",
+                identifier="GHSA-1-2-3",
+                package="pystuff",
+                vulnerable_range="",  # strange, but function should handle it
+            ),
+            PackageConstraints(package="pystuff", specifiers=[]),
+        ),
     ],
 )
 def test_get_safe_version_constraints(


### PR DESCRIPTION
- Use pytest-integration to run integration tests last and without adding to code coverage
- Require 100% unit test coverage and add tests until it is reached
- Use pytest-random-order to ensure tests are independent (confirmed to work with pytest-integration)

close #18 